### PR TITLE
add python version and delete enum dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,4 +15,8 @@ wheel = "*"
 [packages]
 
 "boto3" = "*"
-enum = "*"
+
+
+[requires]
+
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,23 +1,25 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b44cae409c1cc07e2eb76f2d8d6902608defd065454419cdf5db31d4f88eb51f"
+            "sha256": "f7eba71f95040e40c6efc3ef8e1b2f09492c7a88b052786a694ce2ab42ac3df9"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "0",
+            "implementation_version": "3.6.3",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
             "platform_release": "4.13.0-16-generic",
             "platform_system": "Linux",
             "platform_version": "#19-Ubuntu SMP Wed Oct 11 18:35:14 UTC 2017",
-            "python_full_version": "2.7.14",
-            "python_version": "2.7",
-            "sys_platform": "linux2"
+            "python_full_version": "3.6.3",
+            "python_version": "3.6",
+            "sys_platform": "linux"
         },
         "pipfile-spec": 6,
-        "requires": {},
+        "requires": {
+            "python_version": "3.6"
+        },
         "sources": [
             {
                 "name": "pypi",
@@ -48,12 +50,6 @@
                 "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
             ],
             "version": "==0.14"
-        },
-        "enum": {
-            "hashes": [
-                "sha256:54e78526b166982b36884613f35a76d9a6711c49810d3ec1a05b10c9b31f938e"
-            ],
-            "version": "==0.4.6"
         },
         "futures": {
             "hashes": [


### PR DESCRIPTION
# Problem

There is a mistake in the enum lib used because without specification this module us python 2.7 but this module is for use with python 3.6

# Goal

Set the correct python version and remove wrong enum module

# Implementation

done with pipenv

# Mentions

@joaoqalves 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
