### PR TITLE
add values and Mapper because aws has some inconsistences in som retu…

### DIFF
--- a/AWSEnums/general/currency_code.py
+++ b/AWSEnums/general/currency_code.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class CurrencyCode(Enum):
+    USD = "USD"

--- a/AWSEnums/instance/platform.py
+++ b/AWSEnums/instance/platform.py
@@ -2,7 +2,8 @@ from enum import Enum
 
 
 class Platform(Enum):
-    LINUX = "Linux/UNIX"
-    SUSE_LINUX = "SUSE Linux"
-    WINDOWS = "Windows"
-    WINDOWS_SQL = "Windows with SQL Server Standard"
+    LINUX = 'Linux/UNIX'
+    SUSE_LINUX = 'SUSE Linux'
+    WINDOWS = 'Windows'
+    WINDOWS_SQL = 'Windows with SQL Server Standard'
+    UNKNOWN = 'Unknown'

--- a/AWSEnums/instance/type.py
+++ b/AWSEnums/instance/type.py
@@ -105,3 +105,6 @@ class Type(Enum):
     X1E_4XLARGE = "x1e.4xlarge"
     X1E_8XLARGE = "x1e.8xlarge"
     X1E_XLARGE = "x1e.xlarge"
+
+    # Dedicated hosts:
+    I3 = "I3"

--- a/AWSEnums/mapper.py
+++ b/AWSEnums/mapper.py
@@ -1,0 +1,12 @@
+class Mapper(object):
+    @staticmethod
+    def map(enum, value):
+        result = None
+        for enum_value in enum:
+            if Mapper._normalize(value) == Mapper._normalize(enum_value.value):
+                result = enum_value
+        return result
+
+    @staticmethod
+    def _normalize(value: str):
+        return value.lower().replace(" ", "")

--- a/AWSEnums/reserved_instance/scope.py
+++ b/AWSEnums/reserved_instance/scope.py
@@ -3,4 +3,4 @@ from enum import Enum
 
 class Scope(Enum):
     REGION = "Region"
-    AVAILABILITY_ZONES = "Availability Zones"
+    AVAILABILITY_ZONES = "Availability Zone"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='AWSEnums',
-    version='0.0.1.dev7',
+    version='0.0.1.dev8',
 
     description='Python module that contains a list of enums useful for your applications.',
     long_description=long_description,


### PR DESCRIPTION
# Background

After have dedicated hosts we have some new values, and we found some inconsistency in the values returned by aws, for example in the reserved instances subscription type in dedicated hosts returns "AllUpfront" and in the convertible reserved instances "All Upfront"

# Problem

We have errors for the new values and the inconsistency problems

# Goal

solve all the problems

# Implementation

Add the new values and create a mapper that returns the correct value of the enumeration even if there is differences between spaces and capital letters. 

# Mentions

@joaoqalves

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
